### PR TITLE
Mutable API: Specify initialSize independent of capacity

### DIFF
--- a/src/lru.ml
+++ b/src/lru.ml
@@ -242,7 +242,7 @@ module M = struct
 
     let create ?random ?initialSize cap =
       let hashSize =
-        match initialSize with | None  -> 0 | (Some v) -> v in
+        match initialSize with | None -> cap | (Some v) -> v in
       cap_makes_sense ~f:"create" cap;
       { cap; w = 0; ht = HT.create ?random hashSize; q = Q.create () }
 

--- a/src/lru.ml
+++ b/src/lru.ml
@@ -199,7 +199,7 @@ module M = struct
     type t
     type k
     type v
-    val create : ?random:bool -> int -> t
+    val create : ?random:bool -> ?initialSize: int -> int -> t
     val is_empty : t -> bool
     val size : t -> int
     val weight : t -> int
@@ -240,9 +240,11 @@ module M = struct
 
     let cap_makes_sense = cap_makes_sense ~m:"M"
 
-    let create ?random cap =
+    let create ?random ?initialSize cap =
+      let hashSize =
+        match initialSize with | None  -> 0 | (Some v) -> v in
       cap_makes_sense ~f:"create" cap;
-      { cap; w = 0; ht = HT.create ?random cap; q = Q.create () }
+      { cap; w = 0; ht = HT.create ?random hashSize; q = Q.create () }
 
     let lru t = match t.q.Q.first with Some n -> Some n.Q.value | _ -> None
 

--- a/src/lru.mli
+++ b/src/lru.mli
@@ -219,11 +219,14 @@ module M : sig
     type v
     (** Values in {{!t}[t]}. *)
 
-    val create : ?random:bool -> int -> t
-    (** [create ?random cap] is a new map with capacity [cap].
+    val create : ?random:bool -> ?initialSize:int -> int -> t
+    (** [create ?random ?initialSize cap] is a new map with capacity [cap].
 
         [~random] randomizes the underlying hash table. It defaults to [false].
         See {!Hashtbl.create}.
+
+        [~initialSize] sets the initial size of the underlying hash table. If not set,
+        [initialSize] is set to [cap].
 
         {b Note.} The internal hash table is created with size [cap].
 


### PR DESCRIPTION
Hi,

Thank you for the great library! 

For my scenario, it'd be preferable to not pre-allocate the `capacity` when initializing the Lru Hashtable. I'd like to be able to bound the growth, and make guarantees that we do not exceed a certain size, but not necessarily allocate the full set of memory up-front.

This isn't doable with the current API, because the `capacity` passed to the `create` method of the Mutable LRU is used to set the initial size of the `Hashtbl.t`.

To support this, I added an optional `initialSize` parameter to `create` - if not specified, it will default to capacity as before. If it is specified, it is used to set the initial size of the underlying hash table.